### PR TITLE
Re-forminate the chat-client now that we can properly attach :submit handler

### DIFF
--- a/chat/chat-client/app/src/chat_client/web/rendering.cljs
+++ b/chat/chat-client/app/src/chat_client/web/rendering.cljs
@@ -23,31 +23,33 @@
   (condp = transform-name
     :send-message
     ;; Remove class hide from .enter-message
-    (do
-      (dom/remove-class! (dom/by-class "enter-message") "hide")
-      ;; TODO: Enter should also work for submitting
-      (events/send-on-click (dom/by-id "send-message-button")
-                            d
-                            (fn [] (let [text-node (dom/by-id "message-input")
-                                        text (.-value text-node)]
-                                    (set! (.-value text-node) "")
-                                    (msg/fill transform-name messages {:text text})))))
+    (let [enter-message-form (dom/by-class "enter-message")]
+      (dom/remove-class! enter-message-form "hide")
+      (.focus (dom/by-id "message-input"))
+      (events/send-on :submit
+                      enter-message-form
+                      d
+                      (fn [] (let [text-node (dom/by-id "message-input")
+                                  text (.-value text-node)]
+                              (set! (.-value text-node) "")
+                              (msg/fill transform-name messages {:text text})))))
 
     :clear-messages
     (events/send-on-click (dom/by-id "clear-button") d transform-name messages)
 
     :set-nickname
-    (do
+    (let [enter-nickname-form (dom/by-class "enter-nickname")]
       (dom/add-class! (dom/by-id "root") "startup")
-      (dom/remove-class! (dom/by-class "enter-nickname") "hide")
-      ;; TODO: Enter should also work for submitting
-      (events/send-on-click (dom/by-id "set-nickname-button")
-                            d
-                            (fn []
-                              (let [nickname-node (dom/by-id "nickname-input")
-                                    nickname (.-value nickname-node)]
-                                (set! (.-value nickname-node) "")
-                                (msg/fill transform-name messages {:nickname nickname})))))
+      (dom/remove-class! enter-nickname-form "hide")
+      (.focus (dom/by-id "nickname-input"))
+      (events/send-on :submit
+                      enter-nickname-form
+                      d
+                      (fn []
+                        (let [nickname-node (dom/by-id "nickname-input")
+                              nickname (.-value nickname-node)]
+                          (set! (.-value nickname-node) "")
+                          (msg/fill transform-name messages {:nickname nickname})))))
 
     :clear-nickname
     (events/send-on-click (dom/by-class "nickname-icon")
@@ -57,15 +59,15 @@
 (defn form-transform-disable [r [_ path transform-name messages] d]
   (condp = transform-name
     :send-message
-    (do
-      (dom/add-class! (dom/by-class "enter-message") "hide")
-      (dom-events/unlisten! (dom/by-id "send-message-button")))
+    (let [enter-message-form (dom/by-class "enter-message")]
+      (dom/add-class! enter-message-form "hide")
+      (dom-events/unlisten! enter-message-form))
 
     :set-nickname
-    (do
+    (let [enter-nickname-form (dom/by-class "enter-nickname")]
       (dom/remove-class! (dom/by-id "root") "startup")
-      (dom/add-class! (dom/by-class "enter-nickname") "hide")
-      (dom-events/unlisten! (dom/by-id "set-nickname-button")))
+      (dom/add-class! enter-nickname-form "hide")
+      (dom-events/unlisten! enter-nickname-form))
 
     :clear-nickname
     (dom-events/unlisten! (dom/by-class "nickname-icon"))))

--- a/chat/chat-client/app/templates/chat-client.html
+++ b/chat/chat-client/app/templates/chat-client.html
@@ -32,25 +32,23 @@
           <div class='chat-footer'></div>
         </div>
         <div class='chat-bar'>
-
-            <div class='enter-message hide'>
-              <div class='right'>
-                <i class='nickname-icon'></i>
-                <button class='send-button' id="send-message-button" type="submit">Send</button>
-              </div>
-              <i class='message-icon focused'></i>
-              <input id="message-input" type="text" placeholder='Enter a message...'>
+          <form class='enter-message hide'>
+            <div class='right'>
+              <i class='nickname-icon'></i>
+              <button class='send-button' id="send-message-button" type="submit">Send</button>
             </div>
-            <div class='enter-nickname'>
-              <div class='right'>
-                <!-- <i class='message-icon'></i> -->
-                <button class='ok-button' id="set-nickname-button" type="submit">OK!</button>
-              </div>
-              <div class='tooltip'>I know you’re excited but please enter a nickname first.</div>
-              <i class='nickname-icon focused'></i>
-              <input id="nickname-input" type="text" placeholder='Enter your nickname...'>
+            <i class='message-icon focused'></i>
+            <input id="message-input" type="text" placeholder='Enter a message...'>
+          </form>
+          <form class='enter-nickname'>
+            <div class='right'>
+              <!-- <i class='message-icon'></i> -->
+              <button class='ok-button' id="set-nickname-button" type="submit">OK!</button>
             </div>
-
+            <div class='tooltip'>I know you’re excited but please enter a nickname first.</div>
+            <i class='nickname-icon focused'></i>
+            <input id="nickname-input" type="text" placeholder='Enter your nickname...'>
+          </form>
         </div>
       </div>
       <!--


### PR DESCRIPTION
Alright, apparently attaching a `:submit` handler with domina now inexplicably works.

I've changed the HTML elements back to be proper forms, and the enter key and submit buttons both work via normal form submit.

We last tried this before we migrated to this repository, and a lot has changed, so it's hard to pinpoint the root cause.
