### PR TITLE
Emit appropriate deltas to show nickname in Data UI

### DIFF
--- a/chat/chat-client/app/src/chat_client/behavior.clj
+++ b/chat/chat-client/app/src/chat_client/behavior.clj
@@ -116,13 +116,16 @@
 
 (defn- nickname-deltas [nickname]
   (if nickname
-    [[:transform-enable [:chat :form] :clear-nickname [{msg/topic :nickname}]]
+    [[:node-create [:chat :nickname] :map]
+     [:value [:chat :nickname] nickname]
+     [:transform-enable [:chat :form] :clear-nickname [{msg/topic :nickname}]]
      [:transform-enable [:chat :form] :send-message [{msg/topic :outbound
                                                       (msg/param :text) {}
                                                       :nickname nickname}]]
      [:transform-disable [:chat :form] :set-nickname]]
     
-    [[:transform-disable [:chat :form] :clear-nickname]
+    [[:node-destroy [:chat :nickname]]
+     [:transform-disable [:chat :form] :clear-nickname]
      [:transform-disable [:chat :form] :send-message]
      [:transform-enable [:chat :form] :set-nickname [{msg/topic :nickname
                                                       (msg/param :nickname) {}}]]]))


### PR DESCRIPTION
The user's nickname wasn't showing up in the Data UI because we only submitted transform deltas related to the `:nickname`. This commit adds deltas to chat-client.behavior/nickname-deltas that creates a `[:chat :nickname]` node and populates it with the provided nickname when setting a nickname and similarly destroys the node when clearing the nickname,
