### PR TITLE
Make pedestal dependencies in project.clj files non-snapshot

### DIFF
--- a/chat/chat-client/project.clj
+++ b/chat/chat-client/project.clj
@@ -16,8 +16,8 @@
                  [domina "1.0.1"]
                  [ch.qos.logback/logback-classic "1.0.6"]
                  [org.clojure/clojurescript "0.0-1450"]
-                 [io.pedestal/pedestal.app "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.app-tools "0.1.0-SNAPSHOT"]]
+                 [io.pedestal/pedestal.app "0.1.0"]
+                 [io.pedestal/pedestal.app-tools "0.1.0"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :source-paths ["app/src" "app/templates"]
   :resource-paths ["config"]

--- a/chat/chat-server/project.clj
+++ b/chat/chat-server/project.clj
@@ -15,8 +15,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.jetty "0.1.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.1.0"]
+                 [io.pedestal/pedestal.jetty "0.1.0"]
                  [ch.qos.logback/logback-classic "1.0.7"]
                  [org.slf4j/jul-to-slf4j "1.7.2"]
                  [org.slf4j/jcl-over-slf4j "1.7.2"]

--- a/cors/project.clj
+++ b/cors/project.clj
@@ -15,8 +15,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.jetty "0.1.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.1.0"]
+                 [io.pedestal/pedestal.jetty "0.1.0"]
                  [org.slf4j/jul-to-slf4j "1.7.2"]
                  [org.slf4j/jcl-over-slf4j "1.7.2"]
                  [org.slf4j/log4j-over-slf4j "1.7.2"]

--- a/helloworld-app/project.clj
+++ b/helloworld-app/project.clj
@@ -16,8 +16,8 @@
                  [domina "1.0.1"]
                  [ch.qos.logback/logback-classic "1.0.6"]
                  [org.clojure/clojurescript "0.0-1450"]
-                 [io.pedestal/pedestal.app "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.app-tools "0.1.0-SNAPSHOT"]]
+                 [io.pedestal/pedestal.app "0.1.0"]
+                 [io.pedestal/pedestal.app-tools "0.1.0"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :source-paths ["app/src" "app/templates"]
   :resource-paths ["config"]

--- a/ring-middleware/project.clj
+++ b/ring-middleware/project.clj
@@ -15,8 +15,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.jetty "0.1.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.1.0"]
+                 [io.pedestal/pedestal.jetty "0.1.0"]
                  [ch.qos.logback/logback-classic "1.0.7"]
                  [org.slf4j/jul-to-slf4j "1.7.2"]
                  [org.slf4j/jcl-over-slf4j "1.7.2"]

--- a/server-with-links/project.clj
+++ b/server-with-links/project.clj
@@ -15,8 +15,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.jetty "0.1.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.1.0"]
+                 [io.pedestal/pedestal.jetty "0.1.0"]
                  [ch.qos.logback/logback-classic "1.0.7"]
                  [org.slf4j/jul-to-slf4j "1.7.2"]
                  [org.slf4j/jcl-over-slf4j "1.7.2"]

--- a/square-root/project.clj
+++ b/square-root/project.clj
@@ -12,5 +12,5 @@
 (defproject square-root-example "0.1.0-SNAPSHOT"
   :description "Use Heron's method to calculate square roots"
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.app "0.1.0-SNAPSHOT"]]
+                 [io.pedestal/pedestal.app "0.1.0"]]
   :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]})

--- a/template-server/project.clj
+++ b/template-server/project.clj
@@ -15,8 +15,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.0-SNAPSHOT"]
-                 [io.pedestal/pedestal.jetty "0.1.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.1.0"]
+                 [io.pedestal/pedestal.jetty "0.1.0"]
                  [ch.qos.logback/logback-classic "1.0.7"]
                  [org.slf4j/jul-to-slf4j "1.7.2"]
                  [org.slf4j/jcl-over-slf4j "1.7.2"]


### PR DESCRIPTION
Since we don't have snapshot releases available on Maven the sample apps don't work without modifying their defproject invocations.

At least for the moment I've made sample projects rely on release versions and not snapshots.
