### PR TITLE
Minor ring-middleware sample changes

### DIFF
--- a/ring-middleware/project.clj
+++ b/ring-middleware/project.clj
@@ -15,8 +15,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.0"]
-                 [io.pedestal/pedestal.jetty "0.1.0"]
+                 [io.pedestal/pedestal.service "0.1.2"]
+                 [io.pedestal/pedestal.jetty "0.1.2"]
                  [ch.qos.logback/logback-classic "1.0.7"]
                  [org.slf4j/jul-to-slf4j "1.7.2"]
                  [org.slf4j/jcl-over-slf4j "1.7.2"]

--- a/ring-middleware/src/ring_middleware/server.clj
+++ b/ring-middleware/src/ring_middleware/server.clj
@@ -24,7 +24,9 @@
                   (constantly (bootstrap/create-server (merge service/service opts)))))
 
 (defn -main [& args]
+  (println "Creating server...")
   (create-server)
+  (println "Server created. Awaiting connections.")
   (bootstrap/start service-instance))
 
 


### PR DESCRIPTION
Updated Pedestal version to v0.1.2.  Also added a couple of console status messages to inform users that the server is starting and ready.  The old way was confusing at first because it appeared that the lein dependencies download process froze, but the sample app was started and silent.
