### PR TITLE
Updated Pedestal version to v0.1.2.

### DIFF
--- a/square-root/project.clj
+++ b/square-root/project.clj
@@ -12,5 +12,5 @@
 (defproject square-root-example "0.1.0-SNAPSHOT"
   :description "Use Heron's method to calculate square roots"
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.app "0.1.0"]]
+                 [io.pedestal/pedestal.app "0.1.2"]]
   :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]})


### PR DESCRIPTION
Works the same as in the original instructions.
