### PR TITLE
sample bump version numbers? (parked)

### DIFF
--- a/auto-reload-server/project.clj
+++ b/auto-reload-server/project.clj
@@ -4,21 +4,22 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.9-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.1.10"
+                   :exclusions [org.slf4j/slf4j-api]]
 
                  ;; Remove this line and uncomment the next line to
                  ;; use Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.1.9-SNAPSHOT"]
-                 ;; [io.pedestal/pedestal.tomcat "0.1.9-SNAPSHOT"]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 ;; [io.pedestal/pedestal.tomcat "0.1.10"]
 
                  ;; auto-reload changes
                  [ns-tracker "0.2.1"]
 
                  ;; Logging
-                 [ch.qos.logback/logback-classic "1.0.7" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]

--- a/chat/chat-client/project.clj
+++ b/chat/chat-client/project.clj
@@ -12,12 +12,12 @@
 (defproject chat-client "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/tools.namespace "0.2.1"]
+                 [org.clojure/tools.namespace "0.2.4"]
                  [domina "1.0.1"]
-                 [ch.qos.logback/logback-classic "1.0.6"]
-                 [org.clojure/clojurescript "0.0-1450"]
-                 [io.pedestal/pedestal.app "0.1.2"]
-                 [io.pedestal/pedestal.app-tools "0.1.2"]]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.clojure/clojurescript "0.0-1859"]
+                 [io.pedestal/pedestal.app "0.1.10"]
+                 [io.pedestal/pedestal.app-tools "0.1.10"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :source-paths ["app/src" "app/templates"]
   :resource-paths ["config"]

--- a/chat/chat-server/project.clj
+++ b/chat/chat-server/project.clj
@@ -15,12 +15,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.service "0.1.2"]
+                 [io.pedestal/pedestal.service "0.1.2"
+                  :exclusions [org.slf4j/slf4j-api]]
                  [io.pedestal/pedestal.jetty "0.1.2"]
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :resource-paths ["config" "resources"]
   :main ^{:skip-aot true} chat-server.server)

--- a/cors/project.clj
+++ b/cors/project.clj
@@ -15,12 +15,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.service "0.1.3"]
-                 [io.pedestal/pedestal.jetty "0.1.3"]
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]
+                 [io.pedestal/pedestal.service "0.1.10"
+                   :exclusions [org.slf4j/slf4j-api]]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]
                  [ring-cors/ring-cors "0.1.0"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :resource-paths ["config"]

--- a/helloworld-app/project.clj
+++ b/helloworld-app/project.clj
@@ -12,9 +12,10 @@
 (defproject helloworld-app "0.0.1-SNAPSHOT"
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1586"]
+                 [org.clojure/clojurescript "0.0-1859"]
                  [domina "1.0.1"]
-                 [ch.qos.logback/logback-classic "1.0.7" :exclusions [org.slf4j/slf4j-api]]
+                 [ch.qos.logback/logback-classic "1.0.13"
+                  :exclusions [org.slf4j/slf4j-api]]
                  [io.pedestal/pedestal.app "0.1.10"]
                  [io.pedestal/pedestal.app-tools "0.1.10"]]
   :profiles {:dev {:source-paths ["dev"]}}

--- a/jboss/project.clj
+++ b/jboss/project.clj
@@ -3,20 +3,21 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.0"]
-                 [io.pedestal/pedestal.service "0.1.8"]
-                 [org.immutant/immutant "0.9.0"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [io.pedestal/pedestal.service "0.1.10"
+                   :exclusions [org.slf4j/slf4j-api]]
+                 [org.immutant/immutant "1.0.1"]
 
                  ;; Remove this line and uncomment the next line to
                  ;; use Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.1.8"]
-                 ;; [io.pedestal/pedestal.tomcat "0.1.8"]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 ;; [io.pedestal/pedestal.tomcat "0.1.10"]
 
                  ;; Logging
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]]
   :plugins [[lein-immutant "0.18.0"]]
   :immutant  {;:init immutant/init
               :resolve-dependencies true

--- a/ring-middleware/project.clj
+++ b/ring-middleware/project.clj
@@ -15,12 +15,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.service "0.1.2"]
-                 [io.pedestal/pedestal.jetty "0.1.2"]
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]]
+                 [io.pedestal/pedestal.service "0.1.10"
+                   :exclusions [org.slf4j/slf4j-api]]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :resource-paths ["config"]
   :main ^{:skip-aot true} ring-middleware.server)

--- a/server-sent-events/project.clj
+++ b/server-sent-events/project.clj
@@ -4,18 +4,19 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.service "0.1.2"]
+                 [io.pedestal/pedestal.service "0.1.10"
+                   :exclusions [org.slf4j/slf4j-api]]
 
                  ;; Remove this line and uncomment the next line to
                  ;; use Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.1.2"]
-                 ;; [io.pedestal/pedestal.tomcat "0.1.2"]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 ;; [io.pedestal/pedestal.tomcat "0.1.10"]
 
                  ;; Logging
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :min-lein-version "2.0.0"
   :resource-paths ["config"]

--- a/server-with-links/project.clj
+++ b/server-with-links/project.clj
@@ -15,12 +15,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.service "0.1.2"]
-                 [io.pedestal/pedestal.jetty "0.1.2"]
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]]
+                 [io.pedestal/pedestal.service "0.1.10"
+                  :exclusions [org.slf4j/slf4j-api]]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :resource-paths ["config"]
   :main ^{:skip-aot true} server-with-links.server)

--- a/square-root/project.clj
+++ b/square-root/project.clj
@@ -12,5 +12,5 @@
 (defproject square-root-example "0.1.0-SNAPSHOT"
   :description "Use Heron's method to calculate square roots"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.app "0.1.2"]]
+                 [io.pedestal/pedestal.app "0.1.10"]]
   :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]})

--- a/template-server/project.clj
+++ b/template-server/project.clj
@@ -15,14 +15,15 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [io.pedestal/pedestal.service "0.1.5"]
-                 [io.pedestal/pedestal.jetty "0.1.5"]
-                 [ch.qos.logback/logback-classic "1.0.7"]
-                 [org.slf4j/jul-to-slf4j "1.7.2"]
-                 [org.slf4j/jcl-over-slf4j "1.7.2"]
-                 [org.slf4j/log4j-over-slf4j "1.7.2"]
-                 [hiccup "1.0.2"]
-                 [enlive "1.0.1"]
+                 [io.pedestal/pedestal.service "0.1.10"
+                  :exclusions [org.slf4j/slf4j-api]]
+                 [io.pedestal/pedestal.jetty "0.1.10"]
+                 [ch.qos.logback/logback-classic "1.0.13"]
+                 [org.slf4j/jul-to-slf4j "1.7.5"]
+                 [org.slf4j/jcl-over-slf4j "1.7.5"]
+                 [org.slf4j/log4j-over-slf4j "1.7.5"]
+                 [hiccup "1.0.4"]
+                 [enlive "1.1.4"]
                  [comb "0.1.0"]
                  [org.antlr/stringtemplate "4.0.2"]
                  [de.ubercode.clostache/clostache "1.3.1"]]


### PR DESCRIPTION
I did a clean reset of the fork and updated referenced dependency version numbers using `lein ancient` not using automated upgrade, manually checked dependency tree free of conflicts with `log4j` exclusions in the offending package.

Refrained from updating to 0.2.x branch to keep a clean separation in tact.
